### PR TITLE
add tldextract to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pysocks
 pygments
 exchangelib
 trevorproxy
+tldextract


### PR DESCRIPTION
this was required to run the tool on debian 10, sorry for such a pedantic/small PR.