### PR TITLE
fixed missing exception handling for cases where group-alias is None

### DIFF
--- a/trevorspray/lib/sprayers/anyconnect.py
+++ b/trevorspray/lib/sprayers/anyconnect.py
@@ -79,13 +79,17 @@ class AnyConnect(BaseSprayModule):
                 log.error(f"Error parsing content: {e}, {initial_response.content}")
                 return False
             for tunnelgroup in parsed_initial_response.iterfind(".//opaque"):
-                group = tunnelgroup.find("tunnel-group").text
-                groupname = tunnelgroup.find("group-alias").text
-                if group and groupname:
-                    tunnelgroups[groupname] = {
-                        "group": group,
+                group = tunnelgroup.find("tunnel-group")
+                group_alias = tunnelgroup.find("group-alias")
+
+                if group is not None:
+                    group_text = group.text
+                    group_alias_text = group_alias.text if group_alias is not None else group_text
+
+                    tunnelgroups[group_alias_text] = {
+                        "group": group_text,
                         "groupxml": etree.tostring(tunnelgroup).decode(),
-                        "groupname": groupname,
+                        "groupname": group_alias_text,
                     }
 
         # plain auth


### PR DESCRIPTION
This resolves the error that occurs for the anyconnect module when there is no group-alias returned in the config-auth XML

```shell
AttributeError of 'NoneType' object has no attribute 'text'
```

![image](https://github.com/user-attachments/assets/2e14f6d8-c0d2-44b7-b578-825a52939151)

