### PR TITLE
Added option for exporting discovered tenants to a file.

### DIFF
--- a/trevorspray/cli.py
+++ b/trevorspray/cli.py
@@ -63,6 +63,11 @@ def main():
         metavar="DOMAIN",
         help="Retrieves MX records and info related to authentication, email, Azure, Microsoft 365, etc. If --usernames are specified, this also enables username enumeration.",
     )
+    basic_group.add_argument(
+        "--export-tenants",
+        metavar="FILE",
+        help="Export all discovered tenant domains to a file",
+    )
 
     advanced_group = parser.add_argument_group(
         title="advanced arguments",

--- a/trevorspray/lib/discover.py
+++ b/trevorspray/lib/discover.py
@@ -4,6 +4,7 @@ import dns.resolver
 from .util import *
 from contextlib import suppress
 from urllib.parse import urlparse, urlunparse
+from pathlib import Path
 
 log = logging.getLogger("trevorspray.discovery")
 
@@ -55,6 +56,16 @@ class DomainDiscovery:
             loot_file = loot_dir / f"recon_{self.domain}_other_tenant_domains.txt"
             update_file(loot_file, msoldomains)
             log.info(f"Wrote {len(msoldomains):,} domains to {loot_file}")
+            
+            if self.trevor.options.export_tenants:
+                filtered_domains = [d for d in msoldomains if 'onmicrosoft.com' not in d.lower()]
+                export_file = Path(self.trevor.options.export_tenants)
+                export_file.parent.mkdir(parents=True, exist_ok=True)
+                with open(export_file, 'w') as f:
+                    for domain in filtered_domains:
+                        f.write(f"{domain}\n")
+                log.success(f"Exported {len(filtered_domains)} domains to {export_file}")
+        
         self.onedrive_tenantnames()
 
     @staticmethod


### PR DESCRIPTION
This pull request adds the following command line option:

```
--export-tenants <file_path>
```

This will allow a user to export all the tenants found under a tenant to be written to a file. It filters any tenant with `onmicrosoft.com` in the name.