### PR TITLE
AADSTS900023 & AADSTS53003

### DIFF
--- a/trevorspray/lib/sprayers/msol.py
+++ b/trevorspray/lib/sprayers/msol.py
@@ -90,9 +90,17 @@ class MSOL(BaseSprayModule):
                 valid = True
                 msg = f"AADSTS530031: Valid credential, but access policy does not allow token issuance."
 
+            elif "AADSTS53003" in error:
+                valid = True
+                msg = f"AADSTS53003: Valid credential, but access blocked by Conditional Access policies."
+
             elif "AADSTS50034" in error:
                 exists = False
                 msg = f"AADSTS50034: User does not exist."
+
+            elif "AADSTS900023" in error:
+                exists = False
+                msg = f"AADSTS900023: No tenant registered for this domain or invalid domain."
 
             elif "AADSTS50076" in error:
                 valid = True


### PR DESCRIPTION
# Add New Azure AD Error Code Handling

## Changes
Added handling for two new Azure AD error codes in the MSOL sprayer module:

1. `AADSTS900023`: No tenant registered for domain
   - Added error handling for cases where the domain has no registered Azure AD tenant
   - Sets `exists = False` since there is no tenant for the domain
   - Provides clear error message indicating no tenant exists for the domain

2. `AADSTS53003`: Conditional Access Block
   - Added handling for cases where valid credentials are blocked by Conditional Access policies
   - Sets `valid = True` since the credentials are correct
   - Provides descriptive message about the Conditional Access block

## Impact
These changes improve the accuracy of credential validation and error reporting in the MSOL sprayer module by:
- Properly identifying domains without Azure AD tenants
- Correctly identifying valid credentials that are blocked by Conditional Access policies
- Providing more detailed error messages for troubleshooting