### PR TITLE
Add --skip-owa flag to skip OWA discovery during recon

### DIFF
--- a/trevorspray/cli.py
+++ b/trevorspray/cli.py
@@ -75,6 +75,11 @@ def main():
         metavar="FILE",
         help="Export all discovered tenant domains to a file",
     )
+    basic_group.add_argument(
+        "--skip-owa",
+        action="store_true",
+        help="Skip OWA discovery when --recon is used",
+    )
 
     advanced_group = parser.add_argument_group(
         title="advanced arguments",

--- a/trevorspray/lib/discover.py
+++ b/trevorspray/lib/discover.py
@@ -47,7 +47,11 @@ class DomainDiscovery:
 
         self.printjson(self.getuserrealm())
         self.printjson(self.autodiscover())
-        self.owa()
+        
+        if not self.trevor.options.skip_owa:
+            self.owa()
+        else:
+            log.info("Skipping OWA discovery")
 
         msoldomains = self.msoldomains()
         if msoldomains:


### PR DESCRIPTION
Adds a new `--skip-owa` command-line flag that allows users to skip the time-consuming OWA instance discovery when `--recon` is used.