### PR TITLE
Tenant enumeration via DKIM selectors + --user-enum CLI flag

### DIFF
--- a/trevorspray/cli.py
+++ b/trevorspray/cli.py
@@ -22,6 +22,7 @@ sys.path.append(str(package_path))
 
 import lib.util as util
 from .lib import sprayers
+from .lib import enumerators
 from .lib.trevor import TrevorSpray
 from .lib.errors import TREVORSprayError
 
@@ -79,6 +80,12 @@ def main():
         "--skip-owa",
         action="store_true",
         help="Skip OWA discovery when --recon is used",
+    )
+    basic_group.add_argument(
+        "-ue",
+        "--user-enum",
+        choices=list(enumerators.module_choices.keys()),
+        help="User enumeration method to use (skips the interactive prompt)",
     )
 
     advanced_group = parser.add_argument_group(
@@ -208,6 +215,13 @@ def main():
         conflicting_options = [options.subnet, options.ssh, options.proxy]
         if conflicting_options.count(None) + conflicting_options.count([]) < 2:
             log.error("Cannot specify --ssh, --subnet, or --proxy together")
+            sys.exit(1)
+
+        if options.user_enum and not (options.recon and options.users):
+            log.error(
+                "--user-enum/-ue requires both --recon and --users (user "
+                "enumeration only runs in that combination)"
+            )
             sys.exit(1)
 
         if options.ssh and options.threads:

--- a/trevorspray/lib/discover.py
+++ b/trevorspray/lib/discover.py
@@ -29,6 +29,7 @@ class DomainDiscovery:
         self._msoldomains = None
         self._owa = None
         self._onedrive_tenantnames = None
+        self._dkim_tenantnames = None
         self.tenantnames = []
 
     def recon(self):
@@ -47,7 +48,9 @@ class DomainDiscovery:
 
         self.printjson(self.getuserrealm())
         self.printjson(self.autodiscover())
-        
+
+        self.dkim_tenantnames()
+
         if not self.trevor.options.skip_owa:
             self.owa()
         else:
@@ -126,6 +129,69 @@ class DomainDiscovery:
 
         return self._txtrecords
 
+    def dkim_tenantnames(self):
+        """
+        Resolve selector1/selector2 _domainkey CNAMEs to extract the Microsoft 365
+        tenant name (e.g. tesla.com -> teslamotorsinc). Works against both the
+        legacy onmicrosoft.com targets and the newer .microsoft gTLD variant.
+        Reference: https://www.sprocketsecurity.com/blog/tenant-enumeration-is-dead
+        """
+        if self._dkim_tenantnames is not None:
+            return self._dkim_tenantnames
+
+        selectors = ("selector1", "selector2")
+        # Captures the tenant label between "._domainkey." and the Microsoft suffix.
+        # Legacy: <tenant>.onmicrosoft.com   New gTLD: <tenant>.microsoft
+        cname_regex = re.compile(
+            r"\._domainkey\.([a-z0-9-]+)\.(?:onmicrosoft\.com|microsoft)\.?$",
+            re.I,
+        )
+
+        found = []
+        for selector in selectors:
+            qname = f"{selector}._domainkey.{self.domain}"
+            log.info(f"Resolving DKIM selector CNAME at {qname}")
+            try:
+                answers = dns.resolver.query(qname, "CNAME")
+            except Exception as e:
+                log.debug(f"DKIM lookup for {qname} failed: {e}")
+                continue
+            for rdata in answers:
+                target = rdata.to_text().strip().lower()
+                match = cname_regex.search(target)
+                if match:
+                    tenantname = match.group(1)
+                    log.success(
+                        f'Found tenant "{tenantname}" via DKIM selector {qname} -> {target}'
+                    )
+                    found.append(tenantname)
+                else:
+                    log.debug(f"DKIM CNAME {target} did not match Microsoft pattern")
+
+        # Dedupe while preserving order, and merge into the shared tenant list.
+        seen = set()
+        unique = []
+        for name in found:
+            if name not in seen:
+                seen.add(name)
+                unique.append(name)
+        for name in unique:
+            if name not in self.tenantnames:
+                self.tenantnames.append(name)
+
+        if not unique:
+            log.warning(
+                f"No DKIM selector CNAMEs found for {self.domain}. "
+                "This domain may not have DKIM signing configured through "
+                "Exchange Online (third-party gateways like Proofpoint/Mimecast "
+                "typically won't expose it). Tenant names can still be recovered "
+                "by brute-forcing the <tenant>.onmicrosoft.com namespace, but "
+                "TREVORspray does not implement that technique."
+            )
+
+        self._dkim_tenantnames = unique
+        return self._dkim_tenantnames
+
     def autodiscover(self):
         if self._autodiscover is None:
             url = f"https://outlook.office365.com/autodiscover/autodiscover.json/v1.0/test@{self.domain}?Protocol=Autodiscoverv1"
@@ -149,7 +215,7 @@ class DomainDiscovery:
                 data = response.json()
 
                 tenant_name = data.get("tenant_name", "")
-                if tenant_name:
+                if tenant_name and tenant_name not in self.tenantnames:
                     self.tenantnames.append(tenant_name)
 
                 domains = data.get("email_domains", [])

--- a/trevorspray/lib/trevor.py
+++ b/trevorspray/lib/trevor.py
@@ -71,7 +71,9 @@ class TrevorSpray:
             log.info(f"User enumeration enabled with --recon and --users")
             self.user_enum = True
             choices = list(enumerators.module_choices.keys())
-            choice = self.runtimeparams.get("userenum_method", "")
+            choice = getattr(self.options, "user_enum", None) or self.runtimeparams.get(
+                "userenum_method", ""
+            )
             while not choice:
                 log.info(
                     f'Choosing user enumeration method (skip by exporting TREVOR_userenum_method={"|".join(choices)})'


### PR DESCRIPTION
## Summary
- Adds DKIM-selector tenant enumeration to `--recon`: resolves `selector1/selector2._domainkey.<domain>` CNAMEs and extracts the M365 tenant name from the response (handles legacy `onmicrosoft.com` and the new `.microsoft` gTLD variant). The discovered tenant feeds directly into the existing OneDrive validation, so Teams/OneDrive sprayers benefit without extra plumbing.
- When no DKIM CNAMEs exist, warns the operator and notes that tenant names can still be recovered by brute-forcing the `<tenant>.onmicrosoft.com` namespace (not implemented in this tool).
- Adds `-ue` / `--user-enum {teams_photo,onedrive,seamless_sso}` so the user enumeration method can be chosen at invocation time instead of via the interactive prompt or `TREVOR_userenum_method` env var. Rejected unless both `--recon` and `--users` are set.
- Small dedup fix in `msoldomains()` so a tenant found via both DKIM and azmap isn't logged twice.

Reference: https://www.sprocketsecurity.com/blog/tenant-enumeration-is-dead

## Test plan
- [x] `trevorspray --recon tesla.com --skip-owa` → tenant `teslamotorsinc` extracted via DKIM, OneDrive instance confirmed.
- [x] `trevorspray --recon vmware.com --skip-owa` → tenant `onevmw` extracted via DKIM.
- [x] `trevorspray --recon example.com --skip-owa` → no DKIM records, brute-force warning printed.
- [x] `trevorspray --recon tesla.com --skip-owa -u users.txt -ue onedrive` → no interactive prompt, OneDrive enumerator runs.
- [x] `trevorspray -ue onedrive` (no `--recon`/`--users`) → rejected at parse time.
- [x] `trevorspray ... -ue bogus` → argparse rejects invalid choice.