### PR TITLE
Fix/loot timeout

### DIFF
--- a/trevorspray/lib/looters/base.py
+++ b/trevorspray/lib/looters/base.py
@@ -14,6 +14,11 @@ class Looter:
             if callable(getattr(self, func)) and func.startswith("looter_")
         ]
 
+    @property
+    def timeout(self): 
+        """Timeout in seconds from CLI --timeout (default 10).""" 
+        return getattr( getattr(self.sprayer.trevor, "options", None), "timeout", 10 )
+
     def run(self):
         log.info(f"Running loot module: {self.__class__.__name__}")
         for func in self.looters:

--- a/trevorspray/lib/looters/msol.py
+++ b/trevorspray/lib/looters/msol.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import socket
 from ..util import *
 from .base import Looter
 from contextlib import suppress
@@ -29,13 +30,13 @@ class MSOLLooter(Looter):
 
         # curl -v "imaps://outlook.office365.com:993/INBOX" --user "username:password"
         try:
-            session = IMAP4_SSL("outlook.office365.com", 993)
+            session = IMAP4_SSL("outlook.office365.com", 993, timeout=self.timeout)
             log.debug(session.welcome.decode())
             session.login(username, password)
             log.success(f"MFA bypass (IMAP) enabled for {username}!")
             success = True
 
-        except IMAP4.error as e:
+        except (IMAP4.error, socket.timeout, OSError) as e:
             log.warning(f"IMAP MFA bypass failed for {username}: {e}")
 
         except Exception as e:
@@ -59,14 +60,14 @@ class MSOLLooter(Looter):
         hosts = ["outlook.office365.com:587", "smtp.office365.com:587"]
         for host in hosts:
             try:
-                session = smtplib.SMTP(host, timeout=5)
+                session = smtplib.SMTP(host, timeout=self.timeout)
                 log.debug(session.starttls())
                 session.login(username, password)
                 log.success(f"MFA bypass (SMTP) enabled for {username}!")
                 success = True
                 break
 
-            except smtplib.SMTPException as e:
+            except (smtplib.SMTPException, socket.timeout, OSError) as e:
                 log.warning(f"SMTP MFA bypass failed for {username}: {e}")
 
             except Exception as e:
@@ -87,14 +88,14 @@ class MSOLLooter(Looter):
 
         # curl -v "pop3s://outlook.office365.com:995/INBOX" --user "user:password"
         try:
-            session = poplib.POP3_SSL("outlook.office365.com")
+            session = poplib.POP3_SSL("outlook.office365.com", timeout=self.timeout)
             log.debug(session.getwelcome())
             session.user(username)
             session.pass_(password)
             log.success(f"MFA bypass (POP3) enabled for {username}!")
             success = True
 
-        except poplib.error_proto as e:
+        except (poplib.error_proto, socket.timeout, OSError) as e:
             log.warning(f"POP3 MFA bypass failed for {username}: {e}")
 
         except Exception as e:


### PR DESCRIPTION
## Summary Fixes #29 — SMTP/IMAP/POP3 looters could hang indefinitely. 
## Root cause 
- `IMAP4_SSL` and `POP3_SSL` constructors had no timeout parameter. 
- `smtplib.SMTP` used a hardcoded 5-second timeout ignoring `--timeout`. 
- `socket.timeout` was not explicitly caught by protocol-specific handlers. 

## Changes 
- `looters/base.py`: Added `timeout` property that reads `--timeout` (default 10s). 
- `looters/msol.py`: Pass `self.timeout` to IMAP4_SSL, SMTP, and POP3_SSL. 
- `looters/msol.py`: Added `socket.timeout` / `OSError` to each except clause. 

Closes #29 